### PR TITLE
Fix navbar toggle button not working

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -33,8 +33,8 @@
                     Open Source urban simulation software
                 </p>
 
-                <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="Toggle navigation">
-                    <span class="navbar-toggler-icon">&nbsp;</span>
+                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="Toggle navigation">
+                    <span class="navbar-toggler-icon"></span>
                 </button>
 
                 <div class="collapse navbar-collapse" id="navbar">


### PR DESCRIPTION
The problem was a mismatch in the version the syntax was using (BS 4.x) and the version of BS being included (5.2.3).

Fixes issue #1 